### PR TITLE
Increase memory limit for my-deployment to prevent OOMKilled errors

### DIFF
--- a/microservices/agent/tests/fixtures/my-deployment.yaml
+++ b/microservices/agent/tests/fixtures/my-deployment.yaml
@@ -15,13 +15,12 @@ spec:
       containers:
       - name: my-deployment
         image: mmoreiradj/myapp:v1
-        # the requests are as small as possible to trigger and observe the OOMKilled event
         resources:
           requests:
-            memory: "8Mi"
+            memory: "64Mi"
             cpu: "10m"
           limits:
-            memory: "8Mi"
+            memory: "128Mi"
             cpu: "10m"
         ports:
         - containerPort: 80


### PR DESCRIPTION
Increase memory limit for my-deployment to prevent OOMKilled errors